### PR TITLE
Fixed type error in poll_runner.py

### DIFF
--- a/poll_runner.py
+++ b/poll_runner.py
@@ -30,7 +30,6 @@ def main():
 
     config = {
         'vtn_poll_interval': VTN_POLL_INTERVAL,
-        'ven_id':  VEN_ID,
         'vtn_base_uri': BASE_URI,
         'ven_client_cert_key': CLIENT_CERT_KEY_PATH,
         'ven_client_cert_pem': CLIENT_CERT_PATH,


### PR DESCRIPTION
When running poll_runner.py poll.OpenADR2(**config) would choke
upon seeing the first instance of 'ven_id': VEN_ID in the Dictionary.
